### PR TITLE
Minor build fixes for arch linux

### DIFF
--- a/sdlzvterm/build.zig
+++ b/sdlzvterm/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     exe.addIncludePath(b.path("src/"));
 
@@ -17,12 +18,15 @@ pub fn build(b: *std.Build) void {
         .flags = &.{"-Wall"},
     });
 
-    const sdl_dep = b.dependency("SDL",.{
-        .optimize = .ReleaseFast,
-        .target = target,
-    });
-    exe.linkLibrary(sdl_dep.artifact("SDL2"));
-
+    if (b.systemIntegrationOption("sdl2", .{})) {
+        exe.linkSystemLibrary("SDL2");
+    } else {
+        const sdl_dep = b.dependency("SDL", .{
+            .optimize = .ReleaseFast,
+            .target = target,
+        });
+        exe.linkLibrary(sdl_dep.artifact("SDL2"));
+    }
     const zvterm_dep = b.dependency("zvterm", .{
         .target = target,
         .optimize = optimize,

--- a/sdlzvterm/src/main.zig
+++ b/sdlzvterm/src/main.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const c = @cImport({
     @cDefine("_XOPEN_SOURCE", "600");
     @cDefine("_GNU_SOURCE", {});
-    @cInclude("util.h"); // pty.h on linux?
+    if (builtin.os.tag == .linux)
+        @cInclude("pty.h")
+    else
+        @cInclude("util.h");
     @cInclude("SDL2/SDL.h");
 });
 const assert = @import("std").debug.assert;


### PR DESCRIPTION
To use your system install of sdl2, build with:
zig build -fsys=sdl2

This is required on arch linux and some other distros.